### PR TITLE
Fix language selector's height

### DIFF
--- a/src/af/xap/gtk/xap_UnixDlg_Language.ui
+++ b/src/af/xap/gtk/xap_UnixDlg_Language.ui
@@ -203,7 +203,7 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>


### PR DESCRIPTION
On my system, the language selection dialog shows a near-zero-height list
which makes it very difficult to select a language.

I have gtk+ 3.16.6 and I'm under i3.

This simple fix, that is enabling `expand` for `hbox1` did the trick for
me.