### PR TITLE
Explicitly include boost/array.hpp in RealmConnection.cpp

### DIFF
--- a/plugins/collab/backends/service/xp/RealmConnection.cpp
+++ b/plugins/collab/backends/service/xp/RealmConnection.cpp
@@ -16,6 +16,7 @@
  * 02110-1301 USA.
  */
 
+#include <boost/array.hpp>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
This fixes build with boost 1.84.0.